### PR TITLE
String as svector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ NamedTupleTools = "d9ec5142-1e00-5aa0-9d6a-321866360f50"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
@@ -37,6 +38,7 @@ Metis = "1"
 NamedTupleTools = "^0.14"
 Preferences = "1"
 Requires = "1"
+StaticArrays = "1.9.7"
 StatsBase = "0.34"
 julia = "1.9, 1.10, 1.11"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Vahana"
 uuid = "e9033725-1633-496a-b29a-3bc5a5543602"
 authors = ["Steffen Fürst <fuerst@zib.de> and contributors"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1542,7 +1542,7 @@ version = "1.21.0"
     InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [[deps.Vahana]]
-deps = ["ColorSchemes", "Colors", "DataFrames", "Dates", "GraphMakie", "Graphs", "HDF5", "LinearAlgebra", "Logging", "MPI", "MPIPreferences", "Makie", "Metis", "NamedTupleTools", "Preferences", "Printf", "Requires", "StatsBase"]
+deps = ["ColorSchemes", "Colors", "DataFrames", "Dates", "GraphMakie", "Graphs", "HDF5", "LinearAlgebra", "Logging", "MPI", "MPIPreferences", "Makie", "Metis", "NamedTupleTools", "Preferences", "Printf", "Requires", "StaticArrays", "StatsBase"]
 path = "/home/fuerst/.julia/dev/Vahana"
 uuid = "e9033725-1633-496a-b29a-3bc5a5543602"
 version = "1.2.0"

--- a/docs/examples/tutorial1.jl
+++ b/docs/examples/tutorial1.jl
@@ -298,19 +298,14 @@ execution. After these points, the ID should not be considered
 reliable for further use or reference.
 
 If your model requires persistent identification of agents, you should
-implement this yourself by adding an ID field to your agent struct. For
-example:
-
-```
-struct BuyerWithID
-    id::UUID  # created via the UUIDs standard library
-    α::Float64
-    B::Float64
-end
-```
-
-You would then manage these IDs yourself, ensuring they remain
-constant throughout the simulation.
+implement this yourself by adding an ID field to your agent
+struct. You would then manage these IDs yourself, ensuring they remain
+constant throughout the simulation. When working with string-based
+identifiers or other string fields within a struct that need to be
+stored in an HDF5 file, please consult the documentation for the
+[`create_string_converter`](@ref) function. It is also important to note that
+the HDF5 format does not support 128-bit integers. Consequently, the
+UUID package is not compatible with the current version of HDF5.jl.
 
 In our case, we use the IDs returned by add_agents! to iterate over
 all buyer IDs, randomly select `numSellers` seller IDs for each

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -4,6 +4,13 @@ CurrentModule = Vahana
 
 # Change Log
 
+## v1.2.1
+
+### New feature
+
+- Added workaround for strings in structs stored to a HDF5-file. Check
+  the documentation of [`create_string_converter`](@ref) for details.
+
 ## v1.2
 
 ### Breaking changes

--- a/docs/src/hdf5.md
+++ b/docs/src/hdf5.md
@@ -116,8 +116,9 @@ supported.
 The following functions are workarounds for two current restrictions.
 
 ```@docs
-create_namedtuple_converter
 create_enum_converter
+create_namedtuple_converter
+create_string_converter
 ```
 
 ## Example Model

--- a/docs/src/parallel.md
+++ b/docs/src/parallel.md
@@ -113,7 +113,7 @@ function instead.
 
 
 The [Vahana Episim
-example](https://git.zib.de/sfuerst/vahana-episim/episim.jl) serves as
+example](https://git.zib.de/sfuerst/vahana-episim/-/blob/main/src/episim.jl?ref_type=heads) serves as
 a demonstration of how to implement this approach effectively.
 
 ## The :IgnoreSourceState hint

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1542,7 +1542,9 @@ function write_metadata(sim::Simulation,
                  key::Symbol,
                  value)
     if sim.h5file === nothing
-        push!(_preinit_meta, (type, field, key, value))
+        if ! ((type, field, key, value) in _preinit_meta)
+            push!(_preinit_meta, (type, field, key, value))
+        end
         return
     end
 

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -1,4 +1,4 @@
-using MPI, HDF5
+using MPI, HDF5, StaticArrays
 
 import NamedTupleTools: ntfromstruct, structfromnt
 import Dates: format, now
@@ -8,7 +8,7 @@ export write_globals, write_agents, write_edges, write_snapshot
 export read_params, read_globals, read_agents!, read_edges!, read_snapshot!
 export read_agents, read_edges
 export list_snapshots
-export create_namedtuple_converter, create_enum_converter
+export create_namedtuple_converter, create_enum_converter, create_string_converter
 export write_metadata, read_metadata, write_sim_metadata, read_sim_metadata
 
 # hdf5 does not allow to store (unnamed) tuples, but the CartesianIndex
@@ -28,6 +28,65 @@ function create_enum_converter()
     @eval hdf5_type_id(::Type{T}, ::Val{false}) where {I, T <: Enum{I}} = hdf5_type_id(I)
 
     @eval convert(::Type{T}, i::Int32) where { T <: Enum } = T(i)
+end
+
+
+"""
+    create_string_converter(add_show_method::Bool = true)
+
+The HDF5.jl library (version 0.17.2) does not support `InlineStrings`
+or `StaticStrings` in structs. Standard `String`s are also not suitable
+for agent and edge types, as these must be bits types.
+
+To address this limitation, `create_string_converter` generates
+gconversion methods between `String` and `SVector{N, UInt8}` instances
+(from the `StaticArrays` package).  Here, N represents the maximum
+number of bytes that can be stored, which for Unicode strings may
+exceed the character count due to variable-length encoding.
+
+For example, you could create a Person struct with a fixed-size name field:
+
+```julia
+struct Foo
+    foo::SVector{20, UInt8}
+end
+```
+
+You can then construct a `Foo` instance using a regular string:
+`Foo("abc")`.
+
+If `add_show_method` is set to `true` (the default), `show` methods are
+also defined for these `SVector`s. To avoid confusion in the REPL, where
+the value might appear as a `String` while actually being an `SVector`,
+the output includes "(as UInt8-Vector)" after the value itself.
+"""
+function create_string_converter(add_show_method::Bool = true)
+    @eval function Base.convert(::Type{SVector{N, UInt8}}, str::String) where N
+        @mayassert length(codeunits(str)) <= N "str can not be longer then $N bytes"
+        SVector{N, UInt8}(collect(codeunits(rpad(str, N))))
+    end
+
+    @eval Base.promote_rule(::Type{SVector{N, UInt8}}, ::Type{String}) where N =
+        SVector{N, UInt8}
+
+    @eval function Base.convert(::Type{String}, vec::SVector{N, UInt8}) where N
+        String(vec)
+    end
+
+    @eval function Base.convert(::Type{String}, vec::SVector{N, UInt8}) where N
+        rstrip(String(collect(vec)))
+    end
+
+    @eval Base.String(vec::SVector{N, UInt8}) where N = convert(String, vec)
+
+    if add_show_method
+        @eval function Base.show(io::IO, mime::MIME"text/plain", x::SVector{N, UInt8}) where N
+            print(io, String(x) * " (as UInt8-Vector)")
+        end
+        @eval function Base.show(io::IO, x::SVector{N, UInt8}) where N
+            print(io, String(x) * " (as UInt8-Vector)")
+        end
+    end
 end
 
 # import Base.hash

--- a/src/HDF5.jl
+++ b/src/HDF5.jl
@@ -56,9 +56,16 @@ You can then construct a `Foo` instance using a regular string:
 `Foo("abc")`.
 
 If `add_show_method` is set to `true` (the default), `show` methods are
-also defined for these `SVector`s. To avoid confusion in the REPL, where
-the value might appear as a `String` while actually being an `SVector`,
-the output includes "(as UInt8-Vector)" after the value itself.
+also defined for these `SVector`s. To avoid confusion while working
+with Julia's REPL, where the value might appear as a `String` while
+actually being an `SVector`, the output includes "(as UInt8-Vector)"
+after the value itself.
+
+When `add_show_method` is set to `true` (which is the default behavior),
+`show` methods are automatically defined for the `SVector` types. To
+prevent potential confusion arising from the display of `SVector`
+values as `String`s, the output is formatted to include the annotation
+"::UInt8[]" following the value itself. 
 """
 function create_string_converter(add_show_method::Bool = true)
     @eval function Base.convert(::Type{SVector{N, UInt8}}, str::String) where N
@@ -66,6 +73,10 @@ function create_string_converter(add_show_method::Bool = true)
         SVector{N, UInt8}(collect(codeunits(rpad(str, N))))
     end
 
+    @eval function SVector{N, UInt8}(str::String) where N
+        convert(SVector{N, UInt8}, str)
+    end
+    
     @eval Base.promote_rule(::Type{SVector{N, UInt8}}, ::Type{String}) where N =
         SVector{N, UInt8}
 
@@ -81,10 +92,13 @@ function create_string_converter(add_show_method::Bool = true)
 
     if add_show_method
         @eval function Base.show(io::IO, mime::MIME"text/plain", x::SVector{N, UInt8}) where N
-            print(io, String(x) * " (as UInt8-Vector)")
+            print(io, String(x) * "::UInt8[]")
         end
         @eval function Base.show(io::IO, x::SVector{N, UInt8}) where N
-            print(io, String(x) * " (as UInt8-Vector)")
+            print(io, String(x) * "::UInt8[]")
+        end
+        @eval function Base.print(io::IO, x::SVector{N, UInt8}) where N
+            print(io, String(x))
         end
     end
 end


### PR DESCRIPTION
With the current version of HDF5.jl we can not have String (even not Static/InlineStrings) as a fieldtype, but StaticVectors of UInt8. create_string_converter adds some functions to support the convertation of Strings to those StaticVectors.